### PR TITLE
Add `new` constructor for `ScriptPurpose` members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 This Changelog only applies to notable changes of `helios.js` on the main branch.
 
+# 2022/10/27
+* Added `new` constructor for `SpendingScriptPurposeType`, `MintingScriptPurposeType`, 
+`RewardingScriptPurposeType`, and `CertifyingScriptPurposeType`
+
 # 2022/10/26
 * `redeemers` field added to `Tx::new` constructor
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 This Changelog only applies to notable changes of `helios.js` on the main branch.
 
 # 2022/10/27
-* Added `new` constructor for `SpendingScriptPurposeType`, `MintingScriptPurposeType`, 
-`RewardingScriptPurposeType`, and `CertifyingScriptPurposeType`
+* Added `new` constructor for `ScriptPurpose` members
 
 # 2022/10/26
 * `redeemers` field added to `Tx::new` constructor

--- a/all_builtins.txt
+++ b/all_builtins.txt
@@ -93,34 +93,30 @@ methods:     serialize,
 internal ns: __helios__stakingpurpose__certifying
 
 # ScriptPurpose
-associated:  from_data
+associated:  from_data, new_minting, new_spending, new_rewarding, new_certifying
 operators:   __eq, __neq
 methods:     serialize
 internal ns: __helios__scriptpurpose
 
 # ScriptPurpose::Minting
-associated:  new
 operators:   __eq, __neq
 getters:     policy_hash
 methods:     serialize
 internal ns: __helios__scriptpurpose__minting
 
 # ScriptPurpose::Spending
-associated:  new
 operators:   __eq, __neq
 getters:     output_id
 methods:     serialize
 internal ns: __helios__scriptpurpose__spending
 
 # ScriptPurpose::Rewarding
-associated:  new
 operators:   __eq, __neq
 getters:     credential
 methods:     serialize
 internal ns: __helios__scriptpurpose__rewarding
 
 # ScriptPurpose::Certifying
-associated:  new
 operator:    __eq, __neq
 getters:     dcert,
 methods:     serialize,

--- a/all_builtins.txt
+++ b/all_builtins.txt
@@ -99,24 +99,28 @@ methods:     serialize
 internal ns: __helios__scriptpurpose
 
 # ScriptPurpose::Minting
+associated:  new
 operators:   __eq, __neq
 getters:     policy_hash
 methods:     serialize
 internal ns: __helios__scriptpurpose__minting
 
 # ScriptPurpose::Spending
+associated:  new
 operators:   __eq, __neq
 getters:     output_id
 methods:     serialize
 internal ns: __helios__scriptpurpose__spending
 
 # ScriptPurpose::Rewarding
+associated:  new
 operators:   __eq, __neq
 getters:     credential
 methods:     serialize
 internal ns: __helios__scriptpurpose__rewarding
 
 # ScriptPurpose::Certifying
+associated:  new
 operator:    __eq, __neq
 getters:     dcert,
 methods:     serialize,

--- a/helios.js
+++ b/helios.js
@@ -16977,6 +16977,14 @@ class ScriptContextType extends BuiltinType {
 	 */
 	getTypeMember(name) {
 		switch (name.value) {
+			case "new_minting":
+				return Instance.new(new FuncType([new MintingPolicyHashType()], new MintingScriptPurposeType()));
+			case "new_spending":
+				return Instance.new(new FuncType([new TxOutputIdType()], new SpendingScriptPurposeType()));
+			case "new_rewarding":
+				return Instance.new(new FuncType([new StakingCredentialType()], new RewardingScriptPurposeType()));
+			case "new_certifying":
+				return Instance.new(new FuncType([new DCertType()], new CertifyingScriptPurposeType()));
 			case "Minting":
 				return new MintingScriptPurposeType();
 			case "Spending":
@@ -17017,19 +17025,6 @@ class MintingScriptPurposeType extends BuiltinEnumMember {
 
 	/**
 	 * @param {Word} name 
-	 * @returns {EvalEntity}
-	 */
-	 getTypeMember(name) {
-		switch (name.value) {
-			case "new":
-				return Instance.new(new FuncType([new MintingPolicyHashType()], this));
-			default:
-				return super.getTypeMember(name);
-		}
-	}
-
-	/**
-	 * @param {Word} name 
 	 * @returns {Instance}
 	 */
 	getInstanceMember(name) {
@@ -17064,19 +17059,6 @@ class SpendingScriptPurposeType extends BuiltinEnumMember {
 
 	toString() {
 		return "ScriptPurpose::Spending";
-	}
-
-	/**
-	 * @param {Word} name 
-	 * @returns {EvalEntity}
-	 */
-	 getTypeMember(name) {
-		switch (name.value) {
-			case "new":
-				return Instance.new(new FuncType([new TxOutputIdType()], this));
-			default:
-				return super.getTypeMember(name);
-		}
 	}
 
 	/**
@@ -17122,19 +17104,6 @@ class RewardingScriptPurposeType extends BuiltinEnumMember {
 
 	/**
 	 * @param {Word} name 
-	 * @returns {EvalEntity}
-	 */
-	 getTypeMember(name) {
-		switch (name.value) {
-			case "new":
-				return Instance.new(new FuncType([new StakingCredentialType()], this));
-			default:
-				return super.getTypeMember(name);
-		}
-	}
-
-	/**
-	 * @param {Word} name 
 	 * @returns {Instance}
 	 */
 	getInstanceMember(name) {
@@ -17174,18 +17143,6 @@ class CertifyingScriptPurposeType extends BuiltinEnumMember {
 		return "ScriptPurpose::Certifying";
 	}
 
-	/**
-	 * @param {Word} name 
-	 * @returns {EvalEntity}
-	 */
-	 getTypeMember(name) {
-		switch (name.value) {
-			case "new":
-				return Instance.new(new FuncType([new DCertType()], this));
-			default:
-				return super.getTypeMember(name);
-		}
-	}
 
 	/**
 	 * @param {Word} name 
@@ -20330,50 +20287,42 @@ function makeRawFunctions() {
 
 	// ScriptPurpose builtins
 	addDataFuncs("__helios__scriptpurpose");
+	add(new RawFunc("__helios__scriptpurpose__new_minting",
+	`(mintingPolicyHash) -> {
+		__core__constrData(0, __helios__common__list_1(mintingPolicyHash))
+	}`));
+	add(new RawFunc("__helios__scriptpurpose__new_spending",
+	`(output_id) -> {
+		__core__constrData(1, __helios__common__list_1(output_id))
+	}`));
+	add(new RawFunc("__helios__scriptpurpose__new_rewarding",
+	`(cred) -> {
+		__core__constrData(2, __helios__common__list_1(cred))
+	}`));
+	add(new RawFunc("__helios__scriptpurpose__new_certifying",
+	`(dcert) -> {
+		__core__constrData(3, __helios__common__list_1(dcert))
+	}`));
 
 
 	// ScriptPurpose::Minting builtins
 	addEnumDataFuncs("__helios__scriptpurpose__minting");
 	add(new RawFunc("__helios__scriptpurpose__minting__policy_hash", "__helios__common__field_0"));
-	add(new RawFunc("__helios__scriptpurpose__minting__new",
-	`(mintingPolicyHash) -> {
-		__core__constrData(0, __helios__common__list_1(mintingPolicyHash))
-	}
-	`
-	));
 
 	
 	// ScriptPurpose::Spending builtins
 	addEnumDataFuncs("__helios__scriptpurpose__spending");
 	add(new RawFunc("__helios__scriptpurpose__spending__output_id", "__helios__common__field_0"));
-	add(new RawFunc("__helios__scriptpurpose__spending__new",
-	`(output_id) -> {
-		__core__constrData(1, __helios__common__list_1(output_id))
-	}
-	`
-	));
 
 	
 	// ScriptPurpose::Rewarding builtins
 	addEnumDataFuncs("__helios__scriptpurpose__rewarding");
 	add(new RawFunc("__helios__scriptpurpose__rewarding__credential", "__helios__common__field_0"));
-	add(new RawFunc("__helios__scriptpurpose__rewarding__new",
-	`(cred) -> {
-		__core__constrData(2, __helios__common__list_1(cred))
-	}
-	`
-	));
 
 	
 	// ScriptPurpose::Certifying builtins
 	addEnumDataFuncs("__helios__scriptpurpose__certifying");
 	add(new RawFunc("__helios__scriptpurpose__certifying__dcert", "__helios__common__field_0"));
-	add(new RawFunc("__helios__scriptpurpose__certifying__new",
-	`(dcert) -> {
-		__core__constrData(3, __helios__common__list_1(dcert))
-	}
-	`
-	));
 
 
 	// DCert builtins

--- a/helios.js
+++ b/helios.js
@@ -20375,6 +20375,7 @@ function makeRawFunctions() {
 	`
 	));
 
+
 	// DCert builtins
 	addDataFuncs("__helios__dcert");
 	add(new RawFunc("__helios__dcert__new_register",

--- a/helios.js
+++ b/helios.js
@@ -17017,6 +17017,19 @@ class MintingScriptPurposeType extends BuiltinEnumMember {
 
 	/**
 	 * @param {Word} name 
+	 * @returns {EvalEntity}
+	 */
+	 getTypeMember(name) {
+		switch (name.value) {
+			case "new":
+				return Instance.new(new FuncType([new MintingPolicyHashType()], this));
+			default:
+				return super.getTypeMember(name);
+		}
+	}
+
+	/**
+	 * @param {Word} name 
 	 * @returns {Instance}
 	 */
 	getInstanceMember(name) {
@@ -17051,6 +17064,19 @@ class SpendingScriptPurposeType extends BuiltinEnumMember {
 
 	toString() {
 		return "ScriptPurpose::Spending";
+	}
+
+	/**
+	 * @param {Word} name 
+	 * @returns {EvalEntity}
+	 */
+	 getTypeMember(name) {
+		switch (name.value) {
+			case "new":
+				return Instance.new(new FuncType([new TxOutputIdType()], this));
+			default:
+				return super.getTypeMember(name);
+		}
 	}
 
 	/**
@@ -17096,6 +17122,19 @@ class RewardingScriptPurposeType extends BuiltinEnumMember {
 
 	/**
 	 * @param {Word} name 
+	 * @returns {EvalEntity}
+	 */
+	 getTypeMember(name) {
+		switch (name.value) {
+			case "new":
+				return Instance.new(new FuncType([new StakingCredentialType()], this));
+			default:
+				return super.getTypeMember(name);
+		}
+	}
+
+	/**
+	 * @param {Word} name 
 	 * @returns {Instance}
 	 */
 	getInstanceMember(name) {
@@ -17134,7 +17173,20 @@ class CertifyingScriptPurposeType extends BuiltinEnumMember {
 	toString() {
 		return "ScriptPurpose::Certifying";
 	}
-	
+
+	/**
+	 * @param {Word} name 
+	 * @returns {EvalEntity}
+	 */
+	 getTypeMember(name) {
+		switch (name.value) {
+			case "new":
+				return Instance.new(new FuncType([new DCertType()], this));
+			default:
+				return super.getTypeMember(name);
+		}
+	}
+
 	/**
 	 * @param {Word} name 
 	 * @returns {Instance}
@@ -20283,22 +20335,45 @@ function makeRawFunctions() {
 	// ScriptPurpose::Minting builtins
 	addEnumDataFuncs("__helios__scriptpurpose__minting");
 	add(new RawFunc("__helios__scriptpurpose__minting__policy_hash", "__helios__common__field_0"));
+	add(new RawFunc("__helios__scriptpurpose__minting__new",
+	`(mintingPolicyHash) -> {
+		__core__constrData(0, __helios__common__list_1(mintingPolicyHash))
+	}
+	`
+	));
 
 	
 	// ScriptPurpose::Spending builtins
 	addEnumDataFuncs("__helios__scriptpurpose__spending");
 	add(new RawFunc("__helios__scriptpurpose__spending__output_id", "__helios__common__field_0"));
+	add(new RawFunc("__helios__scriptpurpose__spending__new",
+	`(output_id) -> {
+		__core__constrData(1, __helios__common__list_1(output_id))
+	}
+	`
+	));
 
 	
 	// ScriptPurpose::Rewarding builtins
 	addEnumDataFuncs("__helios__scriptpurpose__rewarding");
 	add(new RawFunc("__helios__scriptpurpose__rewarding__credential", "__helios__common__field_0"));
+	add(new RawFunc("__helios__scriptpurpose__rewarding__new",
+	`(cred) -> {
+		__core__constrData(2, __helios__common__list_1(cred))
+	}
+	`
+	));
 
 	
 	// ScriptPurpose::Certifying builtins
 	addEnumDataFuncs("__helios__scriptpurpose__certifying");
 	add(new RawFunc("__helios__scriptpurpose__certifying__dcert", "__helios__common__field_0"));
-
+	add(new RawFunc("__helios__scriptpurpose__certifying__new",
+	`(dcert) -> {
+		__core__constrData(3, __helios__common__list_1(dcert))
+	}
+	`
+	));
 
 	// DCert builtins
 	addDataFuncs("__helios__dcert");


### PR DESCRIPTION
We can construct a spending `ScriptPurpose` as follow:
```javascript
const output_id: TxOutputId = ...
const spending_sp: ScriptPurpose = ScriptPurpose::Spending::new(output_id)
```
