### PR TITLE
Address - Add a Optional Staking Credential

### DIFF
--- a/helios.js
+++ b/helios.js
@@ -25924,11 +25924,12 @@ export class Address extends CborData {
 	 * @param {?Hash} stakingHash
 	 * @returns {Address}
 	 */
-	static fromPubKeyHash(isTestnet, hash, stakingHash) {
-		if (stakingHash) {
+	static fromPubKeyHash(isTestnet, hash, stakingHash = null) {
+		if (stakingHash !== null) {
 			return new Address([isTestnet ? 0x00 : 0x01].concat(hash.bytes).concat(stakingHash.bytes));	
+		} else {
+			return new Address([isTestnet ? 0x60 : 0x61].concat(hash.bytes));
 		}
-		return new Address([isTestnet ? 0x60 : 0x61].concat(hash.bytes));
 	}
 
 	/**
@@ -25939,12 +25940,13 @@ export class Address extends CborData {
 	 * @param {?Hash} stakingHash
 	 * @returns {Address}
 	 */
-	static fromValidatorHash(isTestnet, hash, stakingHash) {
-		if (stakingHash) {
+	static fromValidatorHash(isTestnet, hash, stakingHash = null) {
+		if (stakingHash !== null) {
 			return new Address([isTestnet ? 0x10 : 0x11].concat(hash.bytes).concat(stakingHash.bytes));
+		} else {
+			return new Address([isTestnet ? 0x70 : 0x71].concat(hash.bytes));
 		}
 
-		return new Address([isTestnet ? 0x70 : 0x71].concat(hash.bytes));
 	}
 
 	/**

--- a/helios.js
+++ b/helios.js
@@ -25921,9 +25921,13 @@ export class Address extends CborData {
 	 * Simple payment address without a staking part
 	 * @param {boolean} isTestnet
 	 * @param {PubKeyHash} hash
+	 * @param {?Hash} stakingHash
 	 * @returns {Address}
 	 */
-	static fromPubKeyHash(isTestnet, hash) {
+	static fromPubKeyHash(isTestnet, hash, stakingHash) {
+		if (stakingHash) {
+			return new Address([isTestnet ? 0x00 : 0x01].concat(hash.bytes).concat(stakingHash.bytes));	
+		}
 		return new Address([isTestnet ? 0x60 : 0x61].concat(hash.bytes));
 	}
 
@@ -25932,9 +25936,14 @@ export class Address extends CborData {
 	 * Only relevant for validator scripts
 	 * @param {boolean} isTestnet
 	 * @param {ValidatorHash} hash
+	 * @param {?Hash} stakingHash
 	 * @returns {Address}
 	 */
-	static fromValidatorHash(isTestnet, hash) {
+	static fromValidatorHash(isTestnet, hash, stakingHash) {
+		if (stakingHash) {
+			return new Address([isTestnet ? 0x10 : 0x11].concat(hash.bytes).concat(stakingHash.bytes));
+		}
+
 		return new Address([isTestnet ? 0x70 : 0x71].concat(hash.bytes));
 	}
 


### PR DESCRIPTION
When creating an Address from a Validator or Public Key Hash allow the Developer to also add a Staking Hash. These are appended to the end of the Address (we also need to ensure that the Header is correctly set).

Ref: https://cips.cardano.org/cips/cip19/#shelleyaddresses