### PR TITLE
Export bytesToString function

### DIFF
--- a/helios.js
+++ b/helios.js
@@ -2985,7 +2985,7 @@ export class NetworkParams {
 	}
 	
 	get costModel() {
-		return assertDefined(this.#raw?.costModels?.PlutusScriptV2, "'obj.costModels.PlutusScriptV2' undefined");
+		return assertDefined(this.#raw?.latestParams?.costModels?.PlutusScriptV2, "'obj.latestParams.costModels.PlutusScriptV2' undefined");
 	}
 	/**
 	 * @param {string} key 
@@ -3070,8 +3070,8 @@ export class NetworkParams {
 	 */
 	get txFeeParams() {
 		return [
-			assertNumber(this.#raw?.txFeeFixed),
-			assertNumber(this.#raw?.txFeePerByte),
+			assertNumber(this.#raw?.latestParams?.txFeeFixed),
+			assertNumber(this.#raw?.latestParams?.txFeePerByte),
 		];
 	}
 
@@ -3080,8 +3080,8 @@ export class NetworkParams {
 	 */
 	get exFeeParams() {
 		return [
-			assertNumber(this.#raw?.executionUnitPrices?.priceMemory),
-			assertNumber(this.#raw?.executionUnitPrices?.priceSteps),
+			assertNumber(this.#raw?.latestParams?.executionUnitPrices?.priceMemory),
+			assertNumber(this.#raw?.latestParams?.executionUnitPrices?.priceSteps),
 		];
 	}
 	
@@ -3089,7 +3089,7 @@ export class NetworkParams {
 	 * @type {number[]}
 	 */
 	get sortedCostParams() {
-		let baseObj = this.#raw?.costModels?.PlutusScriptV2;
+		let baseObj = this.#raw?.latestParams?.costModels?.PlutusScriptV2;
 		let keys = Object.keys(baseObj);
 
 		keys.sort();
@@ -3101,21 +3101,21 @@ export class NetworkParams {
 	 * @type {number}
 	 */
 	get lovelacePerUTXOByte() {
-		return assertNumber(this.#raw?.utxoCostPerByte);
+		return assertNumber(this.#raw?.latestParams?.utxoCostPerByte);
 	}
 
 	/**
 	 * @type {number}
 	 */
 	get minCollateralPct() {
-		return assertNumber(this.#raw?.collateralPercentage);
+		return assertNumber(this.#raw?.latestParams?.collateralPercentage);
 	}
 
 	/**
 	 * @type {number}
 	 */
 	get maxCollateralInputs() {
-		return assertNumber(this.#raw?.maxCollateralInputs);
+		return assertNumber(this.#raw?.latestParams?.maxCollateralInputs);
 	}
 
 	/**
@@ -3123,8 +3123,8 @@ export class NetworkParams {
 	 */
 	get txExecutionBudget() {
 		return [
-			assertNumber(this.#raw?.maxTxExecutionUnits?.memory),
-			assertNumber(this.#raw?.maxTxExecutionUnits?.steps),
+			assertNumber(this.#raw?.latestParams?.maxTxExecutionUnits?.memory),
+			assertNumber(this.#raw?.latestParams?.maxTxExecutionUnits?.steps),
 		];
 	}
 
@@ -3132,7 +3132,7 @@ export class NetworkParams {
 	 * @type {number}
 	 */
 	get maxTxSize() {
-		return assertNumber(this.#raw?.maxTxSize);
+		return assertNumber(this.#raw?.latestParams?.maxTxSize);
 	}
 
 	/**

--- a/helios.js
+++ b/helios.js
@@ -80,7 +80,7 @@
 //     2. Utilities                         assert, assertDefined, equals, assertEq, idiv, ipow2, 
 //                                          imask, imod32, imod8, posMod, irotr, bigIntToBytes, 
 //                                          bytesToBigInt, padZeroes, byteToBitString, hexToBytes, 
-//                                          bytesToHex, stringToBytes, bytesToString, replaceTabs, 
+//                                          bytesToHex, stringToBytes, bytesToText, replaceTabs,
 //                                          BitReader, BitWriter, 
 //                                          UInt64, DEFAULT_BASE32_ALPHABET, BECH32_BASE32_ALPHABET, 
 //                                          Crypto, IR, Source, UserError, Site, hl
@@ -591,11 +591,11 @@ function stringToBytes(str) {
 /**
  * Decodes a list of uint8 bytes into a string using UTF-8 encoding.
  * @example
- * bytesToString([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]) => "hello world"
+ * bytesToText([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100]) => "hello world"
  * @param {number[]} bytes 
  * @returns {string}
  */
-export function bytesToString(bytes) {
+export function bytesToText(bytes) {
 	return (new TextDecoder("utf-8", {fatal: true})).decode((new Uint8Array(bytes)).buffer);
 }
 
@@ -1076,17 +1076,17 @@ class Crypto {
 	/**
 	 * Decode base32 string into bytes.
 	 * @example
-	 * bytesToString(Crypto.decodeBase32("my")) => "f"
+	 * bytesToText(Crypto.decodeBase32("my")) => "f"
 	 * @example
-	 * bytesToString(Crypto.decodeBase32("mzxq")) => "fo"
+	 * bytesToText(Crypto.decodeBase32("mzxq")) => "fo"
 	 * @example
-	 * bytesToString(Crypto.decodeBase32("mzxw6")) => "foo"
+	 * bytesToText(Crypto.decodeBase32("mzxw6")) => "foo"
 	 * @example
-	 * bytesToString(Crypto.decodeBase32("mzxw6yq")) => "foob"
+	 * bytesToText(Crypto.decodeBase32("mzxw6yq")) => "foob"
 	 * @example
-	 * bytesToString(Crypto.decodeBase32("mzxw6ytb")) => "fooba"
+	 * bytesToText(Crypto.decodeBase32("mzxw6ytb")) => "fooba"
 	 * @example
-	 * bytesToString(Crypto.decodeBase32("mzxw6ytboi")) => "foobar"
+	 * bytesToText(Crypto.decodeBase32("mzxw6ytboi")) => "foobar"
 	 * @param {string} encoded
 	 * @param {string} alphabet
 	 * @return {number[]}
@@ -6063,7 +6063,7 @@ class UplcBuiltin extends UplcTerm {
 					rte.calcAndIncrCost(this, a);
 
 					try {
-						return new UplcString(callSite, bytesToString(a.bytes));
+						return new UplcString(callSite, bytesToText(a.bytes));
 					} catch(_) {
 						throw callSite.runtimeError("invalid utf-8");
 					}
@@ -7023,7 +7023,7 @@ export class CborData {
 
 		const length = bytes.shift();
 
-		return bytesToString(bytes.splice(0, length));
+		return bytesToText(bytes.splice(0, length));
 	}
 
 	/**
@@ -16755,7 +16755,7 @@ function buildLiteralExprFromValue(site, type, value, path) {
 		}
 	} else if (type instanceof StringType) {
 		if (value instanceof UplcDataValue && value.data instanceof ByteArrayData) {
-			return new PrimitiveLiteralExpr(new StringLiteral(site, bytesToString(value.data.bytes)));
+			return new PrimitiveLiteralExpr(new StringLiteral(site, bytesToText(value.data.bytes)));
 		} else {
 			throw site.typeError(`expected ByteArrayData for parameter '${path}', got '${value}'`);
 		}
@@ -24683,7 +24683,7 @@ class UplcDeserializer extends BitReader {
 	readString() {
 		let bytes = this.readBytes();
 
-		let s = bytesToString(bytes);
+		let s = bytesToText(bytes);
 
 		return new UplcString(Site.dummy(), s);
 	}

--- a/helios.js
+++ b/helios.js
@@ -595,7 +595,7 @@ function stringToBytes(str) {
  * @param {number[]} bytes 
  * @returns {string}
  */
-function bytesToString(bytes) {
+export function bytesToString(bytes) {
 	return (new TextDecoder("utf-8", {fatal: true})).decode((new Uint8Array(bytes)).buffer);
 }
 
@@ -2985,7 +2985,7 @@ export class NetworkParams {
 	}
 	
 	get costModel() {
-		return assertDefined(this.#raw?.latestParams?.costModels?.PlutusScriptV2, "'obj.latestParams.costModels.PlutusScriptV2' undefined");
+		return assertDefined(this.#raw?.costModels?.PlutusScriptV2, "'obj.costModels.PlutusScriptV2' undefined");
 	}
 	/**
 	 * @param {string} key 
@@ -3070,8 +3070,8 @@ export class NetworkParams {
 	 */
 	get txFeeParams() {
 		return [
-			assertNumber(this.#raw?.latestParams?.txFeeFixed),
-			assertNumber(this.#raw?.latestParams?.txFeePerByte),
+			assertNumber(this.#raw?.txFeeFixed),
+			assertNumber(this.#raw?.txFeePerByte),
 		];
 	}
 
@@ -3080,8 +3080,8 @@ export class NetworkParams {
 	 */
 	get exFeeParams() {
 		return [
-			assertNumber(this.#raw?.latestParams?.executionUnitPrices?.priceMemory),
-			assertNumber(this.#raw?.latestParams?.executionUnitPrices?.priceSteps),
+			assertNumber(this.#raw?.executionUnitPrices?.priceMemory),
+			assertNumber(this.#raw?.executionUnitPrices?.priceSteps),
 		];
 	}
 	
@@ -3089,7 +3089,7 @@ export class NetworkParams {
 	 * @type {number[]}
 	 */
 	get sortedCostParams() {
-		let baseObj = this.#raw?.latestParams?.costModels?.PlutusScriptV2;
+		let baseObj = this.#raw?.costModels?.PlutusScriptV2;
 		let keys = Object.keys(baseObj);
 
 		keys.sort();
@@ -3101,21 +3101,21 @@ export class NetworkParams {
 	 * @type {number}
 	 */
 	get lovelacePerUTXOByte() {
-		return assertNumber(this.#raw?.latestParams?.utxoCostPerByte);
+		return assertNumber(this.#raw?.utxoCostPerByte);
 	}
 
 	/**
 	 * @type {number}
 	 */
 	get minCollateralPct() {
-		return assertNumber(this.#raw?.latestParams?.collateralPercentage);
+		return assertNumber(this.#raw?.collateralPercentage);
 	}
 
 	/**
 	 * @type {number}
 	 */
 	get maxCollateralInputs() {
-		return assertNumber(this.#raw?.latestParams?.maxCollateralInputs);
+		return assertNumber(this.#raw?.maxCollateralInputs);
 	}
 
 	/**
@@ -3123,8 +3123,8 @@ export class NetworkParams {
 	 */
 	get txExecutionBudget() {
 		return [
-			assertNumber(this.#raw?.latestParams?.maxTxExecutionUnits?.memory),
-			assertNumber(this.#raw?.latestParams?.maxTxExecutionUnits?.steps),
+			assertNumber(this.#raw?.maxTxExecutionUnits?.memory),
+			assertNumber(this.#raw?.maxTxExecutionUnits?.steps),
 		];
 	}
 
@@ -3132,7 +3132,7 @@ export class NetworkParams {
 	 * @type {number}
 	 */
 	get maxTxSize() {
-		return assertNumber(this.#raw?.latestParams?.maxTxSize);
+		return assertNumber(this.#raw?.maxTxSize);
 	}
 
 	/**
@@ -29392,7 +29392,6 @@ export const exportedForTesting = {
 	hexToBytes: hexToBytes,
 	bytesToHex: bytesToHex,
 	stringToBytes: stringToBytes,
-	bytesToString: bytesToString,
 	dumpCostModels: dumpCostModels,
 	Site: Site,
 	Source: Source,

--- a/test-metadata.js
+++ b/test-metadata.js
@@ -3,9 +3,7 @@
 import {
   Address,
   Assets,
-  ByteArrayData,
   bytesToHex,
-  CborData,
   hexToBytes,
   // MetadataItem,
   MintingPolicyHash,

--- a/test-suite.js
+++ b/test-suite.js
@@ -130,7 +130,7 @@ function isValidString(value) {
         let data = value.data;
         if (data instanceof helios_.ByteArrayData) {
             try {
-                void helios_.bytesToString(data.bytes);
+                void helios.bytesToString(data.bytes);
     
                 return true;
             } catch(_) {
@@ -146,7 +146,7 @@ function asString(value) {
     if (value instanceof helios_.UplcDataValue) {
         let data = value.data;
         if (data instanceof helios_.ByteArrayData) {
-            return helios_.bytesToString(data.bytes);
+            return helios.bytesToString(data.bytes);
         }
     }
 
@@ -1295,7 +1295,7 @@ async function runPropertyTests() {
             let bsa = helios_.Crypto.blake2b(asBytes(a));
 
             try {
-                let aString = helios_.bytesToString(bsa);
+                let aString = helios.bytesToString(bsa);
 
                 return aString == asString(res);
             } catch (_) {

--- a/test-suite.js
+++ b/test-suite.js
@@ -130,7 +130,7 @@ function isValidString(value) {
         let data = value.data;
         if (data instanceof helios_.ByteArrayData) {
             try {
-                void helios.bytesToString(data.bytes);
+                void helios.bytesToText(data.bytes);
     
                 return true;
             } catch(_) {
@@ -146,7 +146,7 @@ function asString(value) {
     if (value instanceof helios_.UplcDataValue) {
         let data = value.data;
         if (data instanceof helios_.ByteArrayData) {
-            return helios.bytesToString(data.bytes);
+            return helios.bytesToText(data.bytes);
         }
     }
 
@@ -1295,7 +1295,7 @@ async function runPropertyTests() {
             let bsa = helios_.Crypto.blake2b(asBytes(a));
 
             try {
-                let aString = helios.bytesToString(bsa);
+                let aString = helios.bytesToText(bsa);
 
                 return aString == asString(res);
             } catch (_) {


### PR DESCRIPTION
This function is helpful for allowing us to more easily resolve the text version of an asset name [as suggested here](https://github.com/Hyperion-BT/PicoSwap/pull/2/files#r1024732850)

~~Updated `NetworkParams` getters to reflect the current structure returned for Babbage era protocol params. This change fixes failing tests.~~