### PR TITLE
re-calculation of script hash needed after updateRedeemedices 

### DIFF
--- a/helios.js
+++ b/helios.js
@@ -35730,6 +35730,9 @@ export class Tx extends CborData {
 		// run updateRedeemerIndices again because new inputs may have been added and sorted
 		this.#witnesses.updateRedeemerIndices(this.#body);
 
+		// re-compute scriptDataHash because redeemer index may have changed
+		this.syncScriptDataHash(networkParams);
+
 		// a bunch of checks
 		this.#body.checkOutputs(networkParams);
 

--- a/src/tx-builder.js
+++ b/src/tx-builder.js
@@ -857,6 +857,9 @@ export class Tx extends CborData {
 		// run updateRedeemerIndices again because new inputs may have been added and sorted
 		this.#witnesses.updateRedeemerIndices(this.#body);
 
+		// re-compute scriptDataHash because redeemer index may have changed
+		this.syncScriptDataHash(networkParams);
+
 		// a bunch of checks
 		this.#body.checkOutputs(networkParams);
 


### PR DESCRIPTION
- re-calculation of script hash needed after call to updateRedeemedices because redeemer index may have changed