### PR TITLE
feat(ed25519): support extended private key as input

### DIFF
--- a/helios.d.ts
+++ b/helios.d.ts
@@ -705,15 +705,17 @@ export class Crypto {
     static get Ed25519(): {
         /**
          * @param {number[]} privateKey
+         * @param {boolean} isExtendedKey
          * @returns {number[]}
          */
-        derivePublicKey: (privateKey: number[]) => number[];
+        derivePublicKey: (privateKey: number[], isExtendedKey?: boolean) => number[];
         /**
          * @param {number[]} message
          * @param {number[]} privateKey
+         * @param {boolean} isExtendedKey
          * @returns {number[]}
          */
-        sign: (message: number[], privateKey: number[]) => number[];
+        sign: (message: number[], privateKey: number[], isExtendedKey?: boolean) => number[];
         /**
          * @param {number[]} signature
          * @param {number[]} message

--- a/helios.js
+++ b/helios.js
@@ -3996,11 +3996,12 @@ export class Crypto {
 		return {
 			/**
 			 * @param {number[]} privateKey 
+			 * @param {boolean} isExtendedKey
 			 * @returns {number[]}
 			 */
-			derivePublicKey: function(privateKey) {
-				const privateKeyHash = Crypto.sha2_512(privateKey);
-				const a = calca(privateKeyHash);
+			derivePublicKey: function(privateKey, isExtendedKey = false) {
+				const extendedKey = isExtendedKey ? privateKey : Crypto.sha2_512(privateKey);
+				const a = calca(extendedKey);
 				const A = scalarMul(BASE, a);
 
 				return encodePoint(A);
@@ -4009,16 +4010,17 @@ export class Crypto {
 			/**
 			 * @param {number[]} message 
 			 * @param {number[]} privateKey 
+			 * @param {boolean} isExtendedKey
 			 * @returns {number[]}
 			 */
-			sign: function(message, privateKey) {
-				const privateKeyHash = Crypto.sha2_512(privateKey);
-				const a = calca(privateKeyHash);
+			sign: function(message, privateKey, isExtendedKey = false) {
+				const extendedKey = isExtendedKey ? privateKey : Crypto.sha2_512(privateKey);
+				const a = calca(extendedKey);
 
 				// for convenience calculate publicKey here:
 				const publicKey = encodePoint(scalarMul(BASE, a));
 
-				const r = ihash(privateKeyHash.slice(32, 64).concat(message));
+				const r = ihash(extendedKey.slice(32, 64).concat(message));
 				const R = scalarMul(BASE, r);
 				const S = posMod(r + ihash(encodePoint(R).concat(publicKey).concat(message))*a, CURVE_ORDER);
 
@@ -4053,6 +4055,7 @@ export class Crypto {
 		}
 	}
 }
+
 
 
 //////////////////////////////////

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -1559,11 +1559,12 @@ export class Crypto {
 		return {
 			/**
 			 * @param {number[]} privateKey 
+			 * @param {boolean} isExtendedKey
 			 * @returns {number[]}
 			 */
-			derivePublicKey: function(privateKey) {
-				const privateKeyHash = Crypto.sha2_512(privateKey);
-				const a = calca(privateKeyHash);
+			derivePublicKey: function(privateKey, isExtendedKey = false) {
+				const extendedKey = isExtendedKey ? privateKey : Crypto.sha2_512(privateKey);
+				const a = calca(extendedKey);
 				const A = scalarMul(BASE, a);
 
 				return encodePoint(A);
@@ -1572,16 +1573,17 @@ export class Crypto {
 			/**
 			 * @param {number[]} message 
 			 * @param {number[]} privateKey 
+			 * @param {boolean} isExtendedKey
 			 * @returns {number[]}
 			 */
-			sign: function(message, privateKey) {
-				const privateKeyHash = Crypto.sha2_512(privateKey);
-				const a = calca(privateKeyHash);
+			sign: function(message, privateKey, isExtendedKey = false) {
+				const extendedKey = isExtendedKey ? privateKey : Crypto.sha2_512(privateKey);
+				const a = calca(extendedKey);
 
 				// for convenience calculate publicKey here:
 				const publicKey = encodePoint(scalarMul(BASE, a));
 
-				const r = ihash(privateKeyHash.slice(32, 64).concat(message));
+				const r = ihash(extendedKey.slice(32, 64).concat(message));
 				const R = scalarMul(BASE, r);
 				const S = posMod(r + ihash(encodePoint(R).concat(publicKey).concat(message))*a, CURVE_ORDER);
 


### PR DESCRIPTION
Many (BIP32-)ED25519 implementations operate on extended (already hashed) private keys. I guess it's a net gain to support both key "forms" as inputs for ED25519 functions. Feel free to suggest a better interface & documentation!

The thing I asked on Discord was adding another constructor for, say, `WalletEmulator` to take in a `ED25519` private key, for backend signing through the `Wallet` interface, instead of manually signing on `tx.bodyHash`. I guess an even better DX is to take in a seed phrase, so new developers don't have to maintain raw keys themselves.