### PR TITLE
fix(cbor): ensure each encoded string chunk is valid utf-8

### DIFF
--- a/helios.d.ts
+++ b/helios.d.ts
@@ -809,8 +809,8 @@ export class CborData {
     static isUtf8(bytes: number[]): boolean;
     /**
      * Encodes a Utf8 string into Cbor bytes.
-     * Strings longer than 64 bytes are split into lists with 64 byte chunks
-     * Note: string splitting isn't reversible
+     * Strings can be split into lists with chunks of up to 64 bytes
+     * to play nice with Cardano tx metadata constraints.
      * @param {string} str
      * @param {boolean} split
      * @returns {number[]}

--- a/src/cbor.js
+++ b/src/cbor.js
@@ -269,8 +269,8 @@ export class CborData {
 
 	/**
 	 * Encodes a Utf8 string into Cbor bytes.
-	 * Strings longer than 64 bytes are split into lists with 64 byte chunks
-	 * Note: string splitting isn't reversible
+	 * Strings can be split into lists with chunks of up to 64 bytes
+	 * to play nice with Cardano tx metadata constraints.
 	 * @param {string} str
 	 * @param {boolean} split
 	 * @returns {number[]}
@@ -282,10 +282,22 @@ export class CborData {
 			/** @type {number[][]} */
 			const chunks = [];
 
-			for (let i = 0; i < bytes.length; i += 64) {
-				const chunk = bytes.slice(i, i + 64);
-
+			let i = 0;
+			while (i < bytes.length) {
+				// We encode the largest chunk up to 64 bytes
+				// that is valid UTF-8
+				let maxChunkLength = 64, chunk;
+				while (true) {
+					try {
+						chunk = bytes.slice(i, i + maxChunkLength);
+						bytesToText(chunk); // Decode to validate utf-8
+						break;
+					} catch(_) {
+						maxChunkLength--;
+					}
+				}
 				chunks.push([120, chunk.length].concat(chunk));
+				i += chunk.length;
 			}
 
 			return CborData.encodeDefList(chunks);
@@ -626,7 +638,7 @@ export class CborData {
 			let i = Number(CborData.decodeInteger(pairBytes));
 
 			fieldDecoder(i, pairBytes);
-			
+
 			done.add(i);
 		});
 

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -27,6 +27,24 @@ export default async function main() {
 
 	tx.addMetadata(406, address.toHex());
 	tx.addMetadata(409, {"map": [["a", 1234], ["other", "this is a test"]]});
+	tx.addMetadata(721, {"map": [
+		[
+		  "919d4c2c9455016289341b1a14dedf697687af31751170d56a31466e",
+		  {
+			map: [
+			  [
+				"UTF8Token",
+				{
+				  map: [
+					["name", "Đồng UTF-8"],
+					["description", "Đây là một mô tả dài được viết với UTF-8. Mục tiêu để kiểm tra xem Helios có chia nhỏ ra đúng không. ヘーリオス（古希: Ἥλιος , Hēlios）は、ギリシア神話の太陽神である。その名はギリシア語で「太陽」を意味する一般名詞と同一である。象徴となる聖鳥は雄鶏。"],
+				  ],
+				},
+			  ],
+			],
+		  },
+		],
+	  ]});
 
 	// Simulate CIP30 `getUtxos()`
 	const walletUTXOs = [


### PR DESCRIPTION
A bit hacky, but it (utilizing the current `TextDecoder` code) is a balance between installing a dependency and writing manual code for UTF-8 chunking and validation.