### PR TITLE
Allow adding multiple reference script witnesses via Tx::addRefInputs

### DIFF
--- a/helios.js
+++ b/helios.js
@@ -45943,7 +45943,8 @@ export class Tx extends CborData {
 	 */
 	addRefInputs(inputs) {
 		for (let input of inputs) {
-			this.addRefInput(input);
+			const refScript = input.origOutput.refScript;
+			this.addRefInput(input, refScript);
 		}
 
 		return this;
@@ -50448,6 +50449,7 @@ export class TxMetadata {
 		return txMetadata;
 	}
 }
+
 
 
 ////////////////////////////////////

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hyperionbt/helios",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@hyperionbt/helios",
-      "version": "0.15.9",
+      "version": "0.15.10",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "typescript": "^4.9.5"

--- a/src/tx-builder.js
+++ b/src/tx-builder.js
@@ -608,7 +608,8 @@ export class Tx extends CborData {
 	 */
 	addRefInputs(inputs) {
 		for (let input of inputs) {
-			this.addRefInput(input);
+			const refScript = input.origOutput.refScript;
+			this.addRefInput(input, refScript);
 		}
 
 		return this;


### PR DESCRIPTION
Before this, we could only add refScript witnesses contained in ref inputs one by one, via `Tx::addRefInput` because `Tx::addRefInputs` didn't actually act on the `refScripts` contained in the refInputs passed to it.