### PR TITLE
feat: Add support for stake registration/de-reg and delegation

### DIFF
--- a/helios-internal.d.ts
+++ b/helios-internal.d.ts
@@ -3252,6 +3252,10 @@ declare module "helios" {
          */
         get maxTxSize(): number;
         /**
+         * @type {bigint}
+         */
+        get stakeAddressDeposit(): bigint;
+        /**
          * Tx balancing picks additional inputs by starting from maxTxFee.
          * This is done because the order of the inputs can have a huge impact on the tx fee, so the order must be known before balancing.
          * If there aren't enough inputs to cover the maxTxFee and the min deposits of newly created UTxOs, the balancing will fail.
@@ -9589,8 +9593,8 @@ declare module "helios" {
          * TODO: implement all DCert (de)serialization methods.
          *
          * Returns the transaction instance so build methods can be chained.
-         * @internal
          * @param {DCert} dcert
+         * @returns {Tx}
          */
         addDCert(dcert: DCert): Tx;
         /**
@@ -9701,8 +9705,9 @@ declare module "helios" {
         correctChangeOutput(networkParams: NetworkParams, changeOutput: TxOutput): void;
         /**
          * @internal
+         * @param {NetworkParams} networkParams
          */
-        checkBalanced(): void;
+        checkBalanced(networkParams: NetworkParams): void;
         /**
          * Shouldn't be used directly
          * @internal
@@ -9839,6 +9844,10 @@ declare module "helios" {
          * @type {PubKeyHash[]}
          */
         get signers(): PubKeyHash[];
+        /**
+         * @type {DCert[]}
+         */
+        get dcerts(): DCert[];
         /**
          * @returns {Object}
          */
@@ -10419,38 +10428,123 @@ declare module "helios" {
     }
     /**
      * A `DCert` represents a staking action (eg. withdrawing rewards, delegating to another pool).
-     * @internal
      */
     export class DCert extends CborData {
         /**
-         * @param {number[]} bytes
+         * @param {string | number[]} raw
          * @returns {DCert}
          */
-        static fromCbor(bytes: number[]): DCert;
+        static fromCbor(raw: string | number[]): DCert;
+        /**
+         * `DCertProps.type` can be:
+         *     `0` for stake registration
+         *     `1` for stake de-registration
+         *     `2` for stake delegation
+         *     `3` for stake pool registration (not yet implemented)
+         *     `4` for stake pool retirement (not yet implemented)
+         *     `5` for genesis key delegation (not yet implemented)
+         *     `6` for moving instantaneous rewards (not yet implemented)
+         *
+         * `DCertProps.credential.type` can be:
+         *     `0` for staking address key hash
+         *     `1` for staking validator key hash (script hash)
+         *
+         * `DCertProps.poolHash` is needed only for stake delegation.
+         * @typedef {{
+         *   type: 0 | 1 | 2,
+         *   credential: {
+         *     type: 0 | 1,
+         *     hash: string
+         *   },
+         *   poolHash?: string
+         * }} DCertProps
+         */
+        /**
+         * Create a DCert from a given json parameter.
+         * @param {string | DCertProps} json
+         * @returns {DCert}
+         */
+        static fromJson(json: string | {
+            type: 0 | 1 | 2;
+            credential: {
+                type: 0 | 1;
+                hash: string;
+            };
+            poolHash?: string | undefined;
+        }): DCert;
         /**
          * @param {UplcData} data
          * @returns {DCert}
          */
         static fromUplcData(data: UplcData): DCert;
         /**
+         * @param {number} certType
+         */
+        constructor(certType: number);
+        /**
+         * Get certificate type.
+         * @type {number}
+         */
+        get certType(): number;
+        /**
+         * Get stake hash.
+         * @type {PubKeyHash | StakingValidatorHash}
+         */
+        get stakeHash(): PubKeyHash | StakingValidatorHash;
+        /**
+         * Get stake credential type.
+         * @type {number}
+         */
+        get credentialType(): number;
+        /**
+         * @returns {number[]}
+         */
+        typeToCbor(): number[];
+        /**
          * @returns {ConstrData}
          */
         toData(): ConstrData;
-    }
-    /**
-     * @internal
-     */
-    export class DCertDelegate extends DCert {
-    }
-    /**
-     * @internal
-     */
-    export class DCertDeregister extends DCert {
+        /**
+         * @returns {Object}
+         */
+        dump(): any;
+        #private;
     }
     /**
      * @internal
      */
     export class DCertRegister extends DCert {
+        /**
+         * @param {PubKeyHash | StakingValidatorHash} stakeHash
+         */
+        constructor(stakeHash: PubKeyHash | StakingValidatorHash);
+        #private;
+    }
+    /**
+     * @internal
+     */
+    export class DCertDeregister extends DCert {
+        /**
+         * @param {PubKeyHash | StakingValidatorHash} stakeHash
+         */
+        constructor(stakeHash: PubKeyHash | StakingValidatorHash);
+        #private;
+    }
+    /**
+     * @internal
+     */
+    export class DCertDelegate extends DCert {
+        /**
+         * @param {PubKeyHash | StakingValidatorHash} stakeHash
+         * @param {PubKeyHash} poolHash
+         */
+        constructor(stakeHash: PubKeyHash | StakingValidatorHash, poolHash: PubKeyHash);
+        /**
+         * Get stake pool hash.
+         * @type {PubKeyHash}
+         */
+        get poolHash(): PubKeyHash;
+        #private;
     }
     /**
      * @internal
@@ -10460,7 +10554,7 @@ declare module "helios" {
     /**
      * @internal
      */
-    export class DCertRetire extends DCert {
+    export class DCertRetirePool extends DCert {
     }
     /**
      * Wrapper for Cardano stake address bytes. An StakeAddress consists of two parts internally:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@helios-lang/compiler",
+  "name": "@hyperionbt/helios",
   "version": "0.15.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@helios-lang/compiler",
+      "name": "@hyperionbt/helios",
       "version": "0.15.13",
       "license": "BSD-3-Clause",
       "devDependencies": {

--- a/src/tx-builder.js
+++ b/src/tx-builder.js
@@ -673,8 +673,8 @@ export class Tx extends CborData {
 	 * TODO: implement all DCert (de)serialization methods.
 	 * 
 	 * Returns the transaction instance so build methods can be chained.
-	 * @internal
-	 * @param {DCert} dcert 
+	 * @param {DCert} dcert
+	 * @returns {Tx}
 	 */
 	addDCert(dcert) {
 		this.#body.addDCert(dcert);
@@ -1028,7 +1028,7 @@ export class Tx extends CborData {
 
 		// assume a change output is always needed
 		const changeOutput = new TxOutput(changeAddress, new Value(0n));
-
+		
 		changeOutput.correctLovelace(networkParams);
 
 		this.#body.addOutput(changeOutput);
@@ -1045,12 +1045,20 @@ export class Tx extends CborData {
 
 		nonChangeOutputValue = feeValue.add(nonChangeOutputValue);
 
+		// stake certificates
+		const stakeAddrDeposit = new Value(networkParams.stakeAddressDeposit);
+		this.#body.dcerts.forEach(dcert => {
+			// in case of stake registrations, count stake key deposits as additional output ADA
+			if (dcert.certType == 0) nonChangeOutputValue = nonChangeOutputValue.add(stakeAddrDeposit);
+			// in case of stake de-registrations, count stake key deposits as additional input ADA
+			if (dcert.certType == 1) inputValue = inputValue.add(stakeAddrDeposit);
+		});
+
 		// this is quite restrictive, but we really don't want to touch UTxOs containing assets just for balancing purposes
 		const spareAssetUTxOs = spareUtxos.some(utxo => !utxo.value.assets.isZero());
 		spareUtxos = spareUtxos.filter(utxo => utxo.value.assets.isZero());
 		
 		// use some spareUtxos if the inputValue doesn't cover the outputs and fees
-
 		const totalOutputValue = nonChangeOutputValue.add(changeOutput.value);
 		while (!inputValue.ge(totalOutputValue)) {
 			let spare = spareUtxos.pop();
@@ -1100,16 +1108,24 @@ export class Tx extends CborData {
 
 	/**
 	 * @internal
+	 * @param {NetworkParams} networkParams
 	 */
-	checkBalanced() {
+	checkBalanced(networkParams) {
+		const stakeAddrDeposit = new Value(networkParams.stakeAddressDeposit);
 		let v = new Value(0n);
 
 		v = this.#body.inputs.reduce((prev, inp) => inp.value.add(prev), v);
+		v = this.#body.dcerts.reduce((prev, dcert) => { // add released stakeAddrDeposit
+            return dcert.certType === 1 ? prev.add(stakeAddrDeposit) : prev
+        }, v);
 		v = v.sub(new Value(this.#body.fee));
 		v = v.add(new Value(0, this.#body.minted));
 		v = this.#body.outputs.reduce((prev, out) => {
 			return prev.sub(out.value)
 		}, v);
+		v = this.#body.dcerts.reduce((prev, dcert) => { // deduct locked stakeAddrDeposit
+            return dcert.certType === 0 ? prev.sub(stakeAddrDeposit) : prev
+        }, v);
 
 		assert(v.lovelace == 0n, `tx not balanced, net lovelace not zero (${v.lovelace})`);
 		assert(v.assets.isZero(), "tx not balanced, net assets not zero");
@@ -1296,7 +1312,7 @@ export class Tx extends CborData {
 
 		this.checkFee(networkParams);
 
-		this.checkBalanced();
+		this.checkBalanced(networkParams);
 
 		this.#valid = true;
 
@@ -1525,6 +1541,13 @@ export class TxBody extends CborData {
 	}
 
 	/**
+	 * @type {DCert[]}
+	 */
+	get dcerts() {
+		return this.#dcerts.slice();
+	}
+
+	/**
 	 * @returns {number[]}
 	 */
 	toCbor() {
@@ -1689,6 +1712,7 @@ export class TxBody extends CborData {
 			minted: this.#minted.isZero() ? null : this.#minted.dump(),
 			metadataHash: this.#metadataHash === null ? null : this.#metadataHash.dump(),
 			scriptDataHash: this.#scriptDataHash === null ? null : this.#scriptDataHash.dump(),
+			certificates: this.#dcerts.length == 0 ? null : this.#dcerts.map(dc => dc.dump()),
 			collateral: this.#collateral.length == 0 ? null : this.#collateral.map(c => c.dump()),
 			signers: this.#signers.length == 0 ? null : this.#signers.map(rs => rs.dump()),
 			collateralReturn: this.#collateralReturn === null ? null : this.#collateralReturn.dump(),
@@ -2019,6 +2043,13 @@ export class TxBody extends CborData {
 	 */
 	addDCert(dcert) {
 		this.#dcerts.push(dcert);
+
+		const reqSigTypes = [1,2]; // stake de-reg, stake deleg
+		if (reqSigTypes.includes(dcert.certType)){
+			if (dcert.credentialType === 0) { // for address key hash only
+				this.addSigner(dcert.stakeHash);
+			}
+		}
 	}
 
 	/**
@@ -3540,19 +3571,190 @@ export class TxOutput extends CborData {
 
 /**
  * A `DCert` represents a staking action (eg. withdrawing rewards, delegating to another pool).
- * @internal
  */
 export class DCert extends CborData {
-	constructor() {
+	#certType;
+
+	#stakeHash;
+
+	#credentialType;
+
+	/**
+     * @param {number} certType
+     */
+	constructor(certType) {
 		super();
+		this.#certType = certType;
 	}
 
 	/**
-	 * @param {number[]} bytes 
+	 * Get certificate type.
+	 * @type {number}
+	 */
+	get certType() {
+		return this.#certType;
+	}
+
+	/**
+	 * Get stake hash.
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	get stakeHash() {
+		return this.#stakeHash;
+	}
+
+	/**
+	 * Get stake credential type.
+	 * @type {number}
+	 */
+	get credentialType() {
+		return this.#credentialType;
+	}
+
+
+	/**
+     * @returns {number[]}
+     */
+    typeToCbor() {
+        return Cbor.encodeInteger(BigInt(this.#certType));
+    }
+
+	/**
+	 * @param {string | number[]} raw
 	 * @returns {DCert}
 	 */
-	static fromCbor(bytes) {
-		throw new Error("not yet implemented");
+	static fromCbor(raw) {
+		const bytes = (typeof raw == "string") ? hexToBytes(raw) : raw;
+
+		if (bytes[0] == 0) {
+            bytes.shift();
+        }
+
+		let certType = -1;
+		let stakeHash, stakeHashType, poolHash;
+
+		/**
+         * @type {DCert | null}
+         */
+        let cert = null;
+
+		Cbor.decodeTuple(bytes, (i, fieldBytes) => {
+			if (i == 0) {
+                certType = Number(Cbor.decodeInteger(fieldBytes))
+            } else {
+				switch(certType) {
+					case 0: // fall through to case 1
+					case 1: // fall through to case 2
+					case 2:
+						if (i == 1)	{
+							Cbor.decodeList(fieldBytes, (i, itemBytes) => {
+								if (i == 0){
+									stakeHashType = Number(Cbor.decodeInteger(itemBytes));
+								} else {
+									if (stakeHashType == 0) { stakeHash = PubKeyHash.fromCbor(itemBytes) }
+									else if (stakeHashType == 1) { stakeHash = StakingValidatorHash.fromCbor(itemBytes) }
+									else { throw new Error("invalid stake credential") }
+								}
+							});
+							if (certType == 0) cert = new DCertRegister(stakeHash);
+							if (certType == 1) cert = new DCertDeregister(stakeHash);
+						} else if (i == 2){
+							poolHash = PubKeyHash.fromCbor(Cbor.decodeBytes(fieldBytes));
+							if (certType == 2) cert = new DCertDelegate(stakeHash, poolHash);
+						}
+						break;
+					case 3: // fall through
+					case 4: // fall through
+					case 5: // fall through
+					case 6:
+						throw new Error("DCert type not yet implemented");
+					default:
+						throw new Error("invalid DCert type");
+				}
+			}
+		});
+
+		if (!cert) {
+            throw new Error("unable to deserialize certificate");
+        } else {
+            return cert;
+        }
+	}
+
+	/**
+	 * `DCertProps.type` can be:
+	 *     `0` for stake registration
+	 *     `1` for stake de-registration
+	 *     `2` for stake delegation
+	 *     `3` for stake pool registration (not yet implemented)
+	 *     `4` for stake pool retirement (not yet implemented)
+	 *     `5` for genesis key delegation (not yet implemented)
+	 *     `6` for moving instantaneous rewards (not yet implemented)
+	 *
+	 * `DCertProps.credential.type` can be:
+	 *     `0` for staking address key hash
+	 *     `1` for staking validator key hash (script hash)
+	 *
+	 * `DCertProps.poolHash` is needed only for stake delegation.
+	 * @typedef {{
+	 *   type: 0 | 1 | 2,
+	 *   credential: {
+	 *     type: 0 | 1,
+	 *     hash: string
+	 *   },
+	 *   poolHash?: string
+	 * }} DCertProps
+	 */
+
+	/**
+	 * Create a DCert from a given json parameter.
+     * @param {string | DCertProps} json
+     * @returns {DCert}
+     */
+    static fromJson(json) {
+		const obj = (typeof json == "string") ? JSON.parse(json) : json;
+        const certType = obj?.type;
+		const stakeHashType = obj.credential.type;
+
+		if (typeof certType !== "number") {
+            throw new Error("invalid or no certificate type specified");
+        }
+
+		let stakeHash, poolHash;
+
+		/**
+         * @type {DCert | null}
+         */
+        let cert = null;
+
+		switch (certType) {
+			case 0: // fall through to case 1
+			case 1: // fall through to case 2
+			case 2:
+				stakeHash = stakeHashType === 0
+				          ? PubKeyHash.fromHex(obj.credential.hash)
+						  : StakingValidatorHash.fromHex(obj.credential.hash);
+				if (certType == 0) cert = new DCertRegister(stakeHash);
+				if (certType == 1) cert = new DCertDeregister(stakeHash);
+				if (certType == 2){
+					poolHash = PubKeyHash.fromHex(obj.poolHash)
+					cert = new DCertDelegate(stakeHash, poolHash);
+				}
+				break;
+			case 3: // fall through
+			case 4: // fall through
+			case 5: // fall through
+			case 6:
+				throw new Error("DCert type not yet implemented");
+			default:
+				throw new Error("invalid DCert type");
+		}
+
+		if (!cert) {
+            throw new Error("unable to deserialize certificate");
+        } else {
+            return cert;
+        }
 	}
 
 	/**
@@ -3569,27 +3771,232 @@ export class DCert extends CborData {
 	toData() {
 		throw new Error("not yet implemented");
 	}
-}
 
-/**
- * @internal
- */
-export class DCertDelegate extends DCert {
-
-}
-
-/**
- * @internal
- */
-export class DCertDeregister extends DCert {
-
+	/**
+	 * @returns {Object}
+	 */
+	dump() {
+		return {}; // placeholder here only, to satisfy call from TxBody.dump (type checking); overwritten by child classes
+	}
 }
 
 /**
  * @internal
  */
 export class DCertRegister extends DCert {
+	/**
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	#stakeHash;
 
+	/**
+	 * @type {number}
+	 */
+	#credentialType;
+
+	/**
+     * @param {PubKeyHash | StakingValidatorHash} stakeHash
+     */
+    constructor(stakeHash) {
+        super(0);
+        assert(stakeHash instanceof PubKeyHash || stakeHash instanceof StakingValidatorHash);
+        this.#stakeHash = stakeHash;
+		this.#credentialType = stakeHash instanceof PubKeyHash ? 0 : 1;
+    }
+
+	/**
+	 * Get stake hash.
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	get stakeHash() {
+		return this.#stakeHash;
+	}
+	
+	/**
+	 * Get stake credential type.
+	 * @type {number}
+	 */
+	get credentialType() {
+		return this.#credentialType;
+	}
+
+	/**
+     * @returns {number[]}
+     */
+    toCbor() {
+        return Cbor.encodeTuple([
+            this.typeToCbor(),
+            Cbor.encodeDefList([
+				Cbor.encodeInteger(BigInt(this.#credentialType)),
+				this.#stakeHash.toCbor()
+			])
+        ]);
+    }
+
+    /**
+	 * @returns {Object}
+	 */
+	dump() {
+		return {
+			certType: "stake_registration",
+			stakeCredential: {
+				type: this.#credentialType,
+				hash: this.#stakeHash.dump()
+			}
+		};
+	}
+}
+
+/**
+ * @internal
+ */
+export class DCertDeregister extends DCert {
+	/**
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	#stakeHash;
+
+	/**
+	 * @type {number}
+	 */
+	#credentialType;
+
+	/**
+     * @param {PubKeyHash | StakingValidatorHash} stakeHash
+     */
+    constructor(stakeHash) {
+        super(1);
+        assert(stakeHash instanceof PubKeyHash || stakeHash instanceof StakingValidatorHash);
+        this.#stakeHash = stakeHash;
+		this.#credentialType = stakeHash instanceof PubKeyHash ? 0 : 1;
+    }
+
+	/**
+	 * Get stake hash.
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	get stakeHash() {
+		return this.#stakeHash;
+	}
+	
+	/**
+	 * Get stake credential type.
+	 * @type {number}
+	 */
+	get credentialType() {
+		return this.#credentialType;
+	}
+
+	/**
+     * @returns {number[]}
+     */
+    toCbor() {
+        return Cbor.encodeTuple([
+            this.typeToCbor(),
+            Cbor.encodeDefList([
+				Cbor.encodeInteger(BigInt(this.#credentialType)),
+				this.#stakeHash.toCbor()
+			])
+        ]);
+    }
+
+    /**
+	 * @returns {Object}
+	 */
+	dump() {
+		return {
+			certType: "stake_deregistration",
+			stakeCredential: {
+				type: this.#credentialType,
+				hash: this.#stakeHash.dump()
+			}
+		};
+	}
+}
+
+/**
+ * @internal
+ */
+export class DCertDelegate extends DCert {
+	/**
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	#stakeHash;
+
+	/**
+	 * @type {number}
+	 */
+	#credentialType;
+
+	/**
+	 * @type {PubKeyHash}
+	 */
+	#poolHash;
+
+	/**
+     * @param {PubKeyHash | StakingValidatorHash} stakeHash
+	 * @param {PubKeyHash} poolHash
+     */
+    constructor(stakeHash, poolHash) {
+        super(2);
+        assert(stakeHash instanceof PubKeyHash || stakeHash instanceof StakingValidatorHash);
+		assert(poolHash instanceof PubKeyHash);
+        this.#stakeHash = stakeHash;
+		this.#credentialType = stakeHash instanceof PubKeyHash ? 0 : 1;
+		this.#poolHash = poolHash;
+    }
+
+	/**
+	 * Get stake hash.
+	 * @type {PubKeyHash | StakingValidatorHash}
+	 */
+	get stakeHash() {
+		return this.#stakeHash;
+	}
+
+	/**
+	 * Get stake credential type.
+	 * @type {number}
+	 */
+	get credentialType() {
+		return this.#credentialType;
+	}
+
+	/**
+	 * Get stake pool hash.
+	 * @type {PubKeyHash}
+	 */
+	get poolHash() {
+		return this.#poolHash;
+	}
+
+	/**
+     * @returns {number[]}
+     */
+    toCbor() {
+        return Cbor.encodeTuple([
+            this.typeToCbor(),
+            Cbor.encodeDefList([
+				Cbor.encodeInteger(BigInt(this.#credentialType)),
+				this.#stakeHash.toCbor()
+			]),
+			this.#poolHash.toCbor()
+        ]);
+    }
+
+    /**
+	 * @returns {Object}
+	 */
+	dump() {
+		return {
+			certType: "stake_delegation",
+			stakeCredential: {
+				type: this.#credentialType,
+				hash: this.#stakeHash.dump()
+			},
+			poolHash: this.#poolHash.dump()
+		};
+	}
 }
 
 /**
@@ -3602,7 +4009,7 @@ export class DCertRegisterPool extends DCert {
 /**
  * @internal
  */
-export class DCertRetire extends DCert {
+export class DCertRetirePool extends DCert {
 
 }
 

--- a/src/uplc-costmodels.js
+++ b/src/uplc-costmodels.js
@@ -241,6 +241,13 @@ export class NetworkParams {
 	}
 
 	/**
+	 * @type {bigint}
+	 */
+	get stakeAddressDeposit() {
+		return BigInt(assertNumber(this.#raw?.latestParams?.stakeAddressDeposit));
+	}
+
+	/**
 	 * Tx balancing picks additional inputs by starting from maxTxFee. 
 	 * This is done because the order of the inputs can have a huge impact on the tx fee, so the order must be known before balancing.
 	 * If there aren't enough inputs to cover the maxTxFee and the min deposits of newly created UTxOs, the balancing will fail.

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -10,7 +10,7 @@
       }
     },
     "..": {
-      "name": "@helios-lang/compiler",
+      "name": "@hyperionbt/helios",
       "version": "0.15.13",
       "license": "BSD-3-Clause",
       "devDependencies": {


### PR DESCRIPTION
This adds partial support for certificates: `stake_registration`, `stake_deregistration`,  and `stake_delegation`.

Leaving out for now the other types of certs since they are not often used in the web/dApp context.

Test txs on preprod:
    * [registration + delegation](https://preprod.cardanoscan.io/transaction/55b747262b560d17af3d868fda9d25e4293cb156601f3c4b152ae2c46aa3f24f?tab=stakecertificates)
    * [change delegation](https://preprod.cardanoscan.io/transaction/42aec6476eda4989b12dddb78cbc89959e9a0666cb7b1165742b9c1f07750dcb?tab=stakecertificates)
    * [de-registration](https://preprod.cardanoscan.io/transaction/fa528b89ee851fbc2fe5c9dca5b6c8c8251f129f6d61695e5ff1bcd4d35a8534?tab=stakecertificates)