### PR TITLE
Update NetworkParam constructor

### DIFF
--- a/helios.js
+++ b/helios.js
@@ -10179,6 +10179,10 @@ export class NetworkParams {
 	 * @param {null | LiveSlotGetter} liveSlotGetter
 	 */
 	constructor(raw, liveSlotGetter = null) {
+	        if(typeof raw !== 'object'){
+		    throw new Error("raw param must be of type object");
+        	}
+
 		this.#raw = raw;
 		this.#liveSlotGetter = liveSlotGetter;
 	}


### PR DESCRIPTION
Added a check to constructor as I found myself passing a non parsed string of network params not even realizing it and Typescript hadn't throw any error because raw is of type 'any'