### PR TITLE
Adding break in refScript Tuple switch

### DIFF
--- a/src/tx-builder.js
+++ b/src/tx-builder.js
@@ -3464,6 +3464,7 @@ export class TxOutput extends CborData {
 										default:
 											throw new Error(`unhandled refScript type ${refScriptType}`);
 									}
+									break;
 								default:
 									throw new Error("unhandled refScript format");
 							}


### PR DESCRIPTION
Just inserting the break so the "unhandled refScript format" doesn't get hit.